### PR TITLE
feat: return success status from agent registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,18 @@ readme = """
 # The webhook that your AI receives messages on.
 ai_webhook = "https://api.sampleurl.com/webhook"
 
-register_with_agentverse(
+success = register_with_agentverse(
     ai_identity,
     ai_webhook,
     AGENTVERSE_KEY,
     name,
     readme,
 )
+
+if success:
+    print(f"Agent successfully registered at: {ai_identity.address}")
+else:
+    print("Failed to register agent")
 ```
 
 #### Handle Requests to Your AI

--- a/cli/register.py
+++ b/cli/register.py
@@ -88,18 +88,23 @@ def register(name, readme, webhook, force):
         ai_identity = Identity.from_seed(agent_key, 0)
 
         # Register the agent with Agentverse
-        register_with_agentverse(
+        success = register_with_agentverse(
             identity=ai_identity,
             url=webhook,
             agentverse_token=agentverse_key,
             agent_title=name,
             readme=readme_content,
         )
-        click.echo(f"Agent successfully registered @ {ai_identity.address}")
-        # Optionally save information to .env file
-        set_key(".env", "AI_IDENTITY", ai_identity.address)
-        set_key(".env", "AI_NAME", name)
-        click.echo("Identity and name saved to .env.")
+
+        if success:
+            click.echo(f"Agent successfully registered @ {ai_identity.address}")
+            # Optionally save information to .env file
+            set_key(".env", "AI_IDENTITY", ai_identity.address)
+            set_key(".env", "AI_NAME", name)
+            click.echo("Identity and name saved to .env.")
+        else:
+            click.echo("Failed to register agent")
+            sys.exit(1)
     except Exception as e:
         click.echo(f"Error registering agent: {str(e)}")
         sys.exit(1)

--- a/cli/register.py
+++ b/cli/register.py
@@ -103,7 +103,7 @@ def register(name, readme, webhook, force):
             set_key(".env", "AI_NAME", name)
             click.echo("Identity and name saved to .env.")
         else:
-            click.echo("Failed to register agent")
+            click.echo(f"Failed to register agent @ {ai_identity.address}")
             sys.exit(1)
     except Exception as e:
         click.echo(f"Error registering agent: {str(e)}")

--- a/docs/ai-communication.mdx
+++ b/docs/ai-communication.mdx
@@ -74,7 +74,7 @@ def init_client():
 
 
         # Register the agent with Agentverse
-        register_with_agentverse(
+        success = register_with_agentverse(
             identity=client_identity,
             url="http://localhost:5002/api/webhook",
             agentverse_token=os.getenv("AGENTVERSE_API_KEY"),
@@ -82,7 +82,11 @@ def init_client():
             readme=readme
         )
 
-        logger.info("Quickstart agent registration complete!")
+        if success:
+            logger.info("Quickstart agent registration complete!")
+        else:
+            logger.error("Failed to register agent")
+            raise Exception("Agent registration failed")
 
     except Exception as e:
         logger.error(f"Initialization error: {e}")
@@ -204,7 +208,7 @@ def init_client():
         """
 
         # Register the agent with Agentverse
-        register_with_agentverse(
+        success = register_with_agentverse(
             identity=client_identity,
             url="http://localhost:5005/api/webhook",
             agentverse_token=os.getenv("AGENTVERSE_API_KEY"),
@@ -212,7 +216,11 @@ def init_client():
             readme=readme
         )
 
-        logger.info("Quickstart agent registration complete!")
+        if success:
+            logger.info("Quickstart agent registration complete!")
+        else:
+            logger.error("Failed to register agent")
+            raise Exception("Agent registration failed")
 
     except Exception as e:
         logger.error(f"Initialization error: {e}")

--- a/docs/register_an_agent.mdx
+++ b/docs/register_an_agent.mdx
@@ -91,13 +91,18 @@ domain:domain-of-your-agent
 # The webhook that your AI receives messages on.
 ai_webhook = "https://api.sampleurl.com/webhook"
 
-register_with_agentverse(
+success = register_with_agentverse(
     ai_identity,
     ai_webhook,
     AGENTVERSE_KEY,
     name,
     readme,
 )
+
+if success:
+    print(f"Agent successfully registered at: {ai_identity.address}")
+else:
+    print("Failed to register agent")
 ```
 
 3. Set up environment variables in a `.env` file (or similar approach):
@@ -113,15 +118,21 @@ AGENT_SECRET_KEY='YOUR_RANDOM_SECRET_SEED'
 4. Run the Script
 
 ```
-python3 regsiter_agent.py
+python3 register_agent.py
 ```
 
-    - __Sample Output:__
+    - __Sample Output (Success):__
 
 ```
-INFO:fetchai:Registering with Almanac API
-INFO:fetchai:Successfully registered as custom agent in Agentverse
-INFO:fetchai:Completed registering agent with Agentverse
+Registering with agentverse
+Agent successfully registered at: agent1qdcdjgc23vdf06sjplvrlqnf8jmyag32y3qygze88a929nv2kuj3yj5s4uu
+```
+
+    - __Sample Output (Failure):__
+
+```
+Registering with agentverse
+Failed to register agent
 ```
 
 
@@ -129,7 +140,7 @@ INFO:fetchai:Completed registering agent with Agentverse
 
 1. __Go to the Agents tab__ in the Agentverse interface.
 
-2. __Select “Local Agents”__ and look for the name used in your script (e.g., “My AI’s Name”).
+2. __Select "Local Agents"__ and look for the name used in your script (e.g., "My AI's Name").
 
 ![local-agent](/img/uagents/local-agent.png)
 
@@ -142,6 +153,6 @@ You have successfully created and registered an AI agent with the Fetch.ai SDK. 
 
 #### Next Steps:
 
-    - Further develop your agent’s code and logic.
+    - Further develop your agent's code and logic.
     - Integrate custom Flask endpoints to handle advanced communication.
-    - Explore additional SDK features (transaction handling, smart contracts, etc.)  to expand the agent’s capabilities.
+    - Explore additional SDK features (transaction handling, smart contracts, etc.)  to expand the agent's capabilities.

--- a/docs/sdk-uagent-communication.mdx
+++ b/docs/sdk-uagent-communication.mdx
@@ -111,15 +111,19 @@ def init_client():
         """
 
         # Register the agent with Agentverse
-        register_with_agentverse(
+        success = register_with_agentverse(
             identity=client_identity,
             url="http://localhost:5002/api/webhook",
-            agentverse_token = os.getenv("AGENTVERSE_API_KEY"),
-            agent_title="Sample AI Agent communication"
+            agentverse_token=os.getenv("AGENTVERSE_API_KEY"),
+            agent_title="Sample AI Agent communication",
             readme=readme
         )
 
-        logger.info("Client agent registration complete!")
+        if success:
+            logger.info("Client agent registration complete!")
+        else:
+            logger.error("Failed to register agent")
+            raise Exception("Agent registration failed")
 
     except Exception as e:
         logger.error(f"Initialization error: {e}")
@@ -316,8 +320,8 @@ INFO:werkzeug:127.0.0.1 - - [30/Jan/2025 14:21:58] "POST /api/webhook HTTP/1.1" 
 
 ## Key Takeaways
 
-- The __uAgent__ handles structured messages using Fetch.ai’s uAgents framework.
-- The __AI Agent__ utilizes Fetch.ai’s SDK for message transmission and parsing.
+- The __uAgent__ handles structured messages using Fetch.ai's uAgents framework.
+- The __AI Agent__ utilizes Fetch.ai's SDK for message transmission and parsing.
 - Communication between the two agents follows a request-response pattern using their respective handlers.
 
 

--- a/examples/readme-agent/README.md
+++ b/examples/readme-agent/README.md
@@ -71,7 +71,15 @@ poetry run python readme_agent/register_agent.py
 You should see an output like this:
 
 ```shell
-Registered agent at <Agentverse address>
+Registering with agentverse
+Registered agent at: <Agentverse address>
+```
+
+If registration fails, you will see:
+
+```shell
+Registering with agentverse
+Failed to register agent
 ```
 
 ## Send a message to your agent via Agentverse

--- a/examples/readme-agent/readme_agent/register_agent.py
+++ b/examples/readme-agent/readme_agent/register_agent.py
@@ -1,13 +1,12 @@
-from readme_agent.readme_utils import extract_readme
 from fetchai.registration import register_with_agentverse
+from fetchai.schema import AgentGeoLocation
+from readme_agent.readme_utils import extract_readme
 from readme_agent.settings import (
     AGENT_IDENTITY,
     AGENTVERSE_KEY,
     MY_AGENT_NAME,
     MY_WEBHOOK_URL,
 )
-
-from fetchai.schema import AgentGeoLocation
 
 
 def main():
@@ -36,7 +35,7 @@ def main():
     }
 
     print("Registering with agentverse")
-    register_with_agentverse(
+    success = register_with_agentverse(
         AGENT_IDENTITY,
         MY_WEBHOOK_URL,
         AGENTVERSE_KEY,
@@ -46,7 +45,10 @@ def main():
         metadata,
         is_public=False,
     )
-    print("Registered agent at:", AGENT_IDENTITY.address)
+    if success:
+        print("Registered agent at:", AGENT_IDENTITY.address)
+    else:
+        print("Failed to register agent")
 
 
 if __name__ == "__main__":

--- a/fetchai/registration.py
+++ b/fetchai/registration.py
@@ -1,13 +1,12 @@
 from uagents_core.config import DEFAULT_AGENTVERSE_URL, AgentverseConfig
+from uagents_core.contrib.protocols.chat import chat_protocol_spec
 from uagents_core.identity import Identity
 from uagents_core.registration import AgentUpdates, AgentverseConnectRequest
 from uagents_core.types import AgentType
 from uagents_core.utils.registration import register_in_agentverse, register_in_almanac
-from uagents_core.contrib.protocols.chat import chat_protocol_spec
 
 from fetchai.logger import get_logger
 from fetchai.schema import AgentGeoLocation
-
 
 logger = get_logger(__name__)
 
@@ -25,7 +24,7 @@ def register_with_agentverse(
     agent_type: AgentType = "custom",
     is_public: bool = True,
     agentverse_base_url: str = DEFAULT_AGENTVERSE_URL,
-) -> None:
+) -> bool:
     """
     Register the agent with the Agentverse API.
     :param identity: The identity of the agent.
@@ -38,7 +37,7 @@ def register_with_agentverse(
     :param geo_location: The location of the agent
     :param is_public: Denotes if the agent should be retrieved by Agentverse search by default.
     :param agentverse_base_url: The base url of the Agentverse environment we would like to use.
-    :return:
+    :return: True if registration was successful in both Almanac and Agentverse, False otherwise.
     """
 
     agentverse_config = AgentverseConfig(base_url=agentverse_base_url)
@@ -60,7 +59,7 @@ def register_with_agentverse(
             )
         metadata["geolocation"] = geo_location.as_str_dict()
 
-    register_in_almanac(
+    register_in_almanac_success = register_in_almanac(
         identity=identity,
         endpoints=[almanac_url],
         protocol_digests=[protocol_digest],
@@ -68,7 +67,7 @@ def register_with_agentverse(
         agentverse_config=agentverse_config,
     )
 
-    register_in_agentverse(
+    register_in_agentverse_success = register_in_agentverse(
         request=AgentverseConnectRequest(
             user_token=agentverse_token,
             agent_type=agent_type,
@@ -81,3 +80,5 @@ def register_with_agentverse(
         ),
         agentverse_config=agentverse_config,
     )
+
+    return bool(register_in_agentverse_success and register_in_almanac_success)

--- a/fetchai/registration.py
+++ b/fetchai/registration.py
@@ -81,4 +81,10 @@ def register_with_agentverse(
         agentverse_config=agentverse_config,
     )
 
+    if not register_in_almanac_success:
+        logger.warning("Failed to register agent in Almanac")
+
+    if not register_in_agentverse_success:
+        logger.warning("Failed to register agent in Agentverse")
+
     return bool(register_in_agentverse_success and register_in_almanac_success)

--- a/fetchai/registration.py
+++ b/fetchai/registration.py
@@ -67,6 +67,10 @@ def register_with_agentverse(
         agentverse_config=agentverse_config,
     )
 
+    if not register_in_almanac_success:
+        logger.warning("Failed to register agent in Almanac")
+        return False
+
     register_in_agentverse_success = register_in_agentverse(
         request=AgentverseConnectRequest(
             user_token=agentverse_token,
@@ -80,9 +84,6 @@ def register_with_agentverse(
         ),
         agentverse_config=agentverse_config,
     )
-
-    if not register_in_almanac_success:
-        logger.warning("Failed to register agent in Almanac")
 
     if not register_in_agentverse_success:
         logger.warning("Failed to register agent in Agentverse")

--- a/fetchai/tests/test_registration.py
+++ b/fetchai/tests/test_registration.py
@@ -44,22 +44,20 @@ class TestRegisterWithAgentverse:
             assert mock_almanac.call_count == 1
             assert mock_agentverse.call_count == 1
 
-    def test_returns_false_when_almanac_registration_fails(
-        self, registration_params: dict
-    ):
+    def test_agentverse_not_called_if_almanac_fails(self, registration_params: dict):
         with (
             mock.patch(
                 "fetchai.registration.register_in_almanac", return_value=False
             ) as mock_almanac,
             mock.patch(
-                "fetchai.registration.register_in_agentverse", return_value=True
+                "fetchai.registration.register_in_agentverse"
             ) as mock_agentverse,
         ):
             result = register_with_agentverse(**registration_params)
 
             assert result is False
             assert mock_almanac.call_count == 1
-            assert mock_agentverse.call_count == 1
+            mock_agentverse.assert_not_called()
 
     def test_returns_false_when_agentverse_registration_fails(
         self, registration_params: dict
@@ -67,23 +65,6 @@ class TestRegisterWithAgentverse:
         with (
             mock.patch(
                 "fetchai.registration.register_in_almanac", return_value=True
-            ) as mock_almanac,
-            mock.patch(
-                "fetchai.registration.register_in_agentverse", return_value=False
-            ) as mock_agentverse,
-        ):
-            result = register_with_agentverse(**registration_params)
-
-            assert result is False
-            assert mock_almanac.call_count == 1
-            assert mock_agentverse.call_count == 1
-
-    def test_returns_false_when_both_registrations_fail(
-        self, registration_params: dict
-    ):
-        with (
-            mock.patch(
-                "fetchai.registration.register_in_almanac", return_value=False
             ) as mock_almanac,
             mock.patch(
                 "fetchai.registration.register_in_agentverse", return_value=False

--- a/fetchai/tests/test_registration.py
+++ b/fetchai/tests/test_registration.py
@@ -1,0 +1,208 @@
+from unittest import mock
+
+import pytest
+from uagents_core.config import AgentverseConfig
+from uagents_core.identity import Identity
+
+from fetchai.registration import register_with_agentverse
+from fetchai.schema import AgentGeoLocation
+
+
+class TestRegisterWithAgentverse:
+    @pytest.fixture
+    def identity(self) -> Identity:
+        return Identity.from_seed("TESTING", 1)
+
+    @pytest.fixture
+    def registration_params(self, identity: Identity) -> dict:
+        return {
+            "identity": identity,
+            "url": "https://api.sampleurl.com/webhook",
+            "agentverse_token": "test_token",
+            "agent_title": "Test Agent",
+            "readme": "README content",
+        }
+
+    @pytest.fixture
+    def mock_agentverse_config(self) -> mock.Mock:
+        return mock.create_autospec(AgentverseConfig, instance=True)
+
+    def test_returns_true_when_both_registrations_succeed(
+        self, registration_params: dict
+    ):
+        with (
+            mock.patch(
+                "fetchai.registration.register_in_almanac", return_value=True
+            ) as mock_almanac,
+            mock.patch(
+                "fetchai.registration.register_in_agentverse", return_value=True
+            ) as mock_agentverse,
+        ):
+            result = register_with_agentverse(**registration_params)
+
+            assert result is True
+            assert mock_almanac.call_count == 1
+            assert mock_agentverse.call_count == 1
+
+    def test_returns_false_when_almanac_registration_fails(
+        self, registration_params: dict
+    ):
+        with (
+            mock.patch(
+                "fetchai.registration.register_in_almanac", return_value=False
+            ) as mock_almanac,
+            mock.patch(
+                "fetchai.registration.register_in_agentverse", return_value=True
+            ) as mock_agentverse,
+        ):
+            result = register_with_agentverse(**registration_params)
+
+            assert result is False
+            assert mock_almanac.call_count == 1
+            assert mock_agentverse.call_count == 1
+
+    def test_returns_false_when_agentverse_registration_fails(
+        self, registration_params: dict
+    ):
+        with (
+            mock.patch(
+                "fetchai.registration.register_in_almanac", return_value=True
+            ) as mock_almanac,
+            mock.patch(
+                "fetchai.registration.register_in_agentverse", return_value=False
+            ) as mock_agentverse,
+        ):
+            result = register_with_agentverse(**registration_params)
+
+            assert result is False
+            assert mock_almanac.call_count == 1
+            assert mock_agentverse.call_count == 1
+
+    def test_returns_false_when_both_registrations_fail(
+        self, registration_params: dict
+    ):
+        with (
+            mock.patch(
+                "fetchai.registration.register_in_almanac", return_value=False
+            ) as mock_almanac,
+            mock.patch(
+                "fetchai.registration.register_in_agentverse", return_value=False
+            ) as mock_agentverse,
+        ):
+            result = register_with_agentverse(**registration_params)
+
+            assert result is False
+            assert mock_almanac.call_count == 1
+            assert mock_agentverse.call_count == 1
+
+    def test_calls_functions_with_correct_parameters(self, registration_params: dict):
+        geo_location = AgentGeoLocation(latitude=51.5074, longitude=-0.1278, radius=1.0)
+        metadata = {"test_key": "test_value"}
+
+        with (
+            mock.patch(
+                "fetchai.registration.register_in_almanac", return_value=True
+            ) as mock_almanac,
+            mock.patch(
+                "fetchai.registration.register_in_agentverse", return_value=True
+            ) as mock_agentverse,
+        ):
+            register_with_agentverse(
+                geo_location=geo_location,
+                metadata=metadata,
+                agent_type="proxy",
+                **registration_params,
+            )
+
+            mock_almanac.assert_called_once()
+            almanac_call_args = mock_almanac.call_args
+            assert (
+                almanac_call_args.kwargs["identity"] == registration_params["identity"]
+            )
+            assert almanac_call_args.kwargs["protocol_digests"] == [
+                "proto:30a801ed3a83f9a0ff0a9f1e6fe958cb91da1fc2218b153df7b6cbf87bd33d62"
+            ]
+            expected_metadata = {
+                "test_key": "test_value",
+                "is_public": "True",
+                "geolocation": geo_location.as_str_dict(),
+            }
+            assert almanac_call_args.kwargs["metadata"] == expected_metadata
+
+            mock_agentverse.assert_called_once()
+            agentverse_call_args = mock_agentverse.call_args
+            assert (
+                agentverse_call_args.kwargs["identity"]
+                == registration_params["identity"]
+            )
+            assert (
+                agentverse_call_args.kwargs["request"].user_token
+                == registration_params["agentverse_token"]
+            )
+            assert agentverse_call_args.kwargs["request"].agent_type == "proxy"
+            assert (
+                agentverse_call_args.kwargs["request"].endpoint
+                == registration_params["url"]
+            )
+            assert (
+                agentverse_call_args.kwargs["agent_details"].name
+                == registration_params["agent_title"]
+            )
+            assert (
+                agentverse_call_args.kwargs["agent_details"].readme
+                == registration_params["readme"]
+            )
+
+    def test_handles_proxy_agent_type_correctly(
+        self, registration_params: dict, mock_agentverse_config: mock.Mock
+    ):
+        with (
+            mock.patch(
+                "fetchai.registration.register_in_almanac", return_value=True
+            ) as mock_almanac,
+            mock.patch(
+                "fetchai.registration.register_in_agentverse", return_value=True
+            ),
+            mock.patch(
+                "fetchai.registration.AgentverseConfig",
+                return_value=mock_agentverse_config,
+            ),
+        ):
+            register_with_agentverse(agent_type="proxy", **registration_params)
+
+            almanac_call_args = mock_almanac.call_args
+            assert almanac_call_args.kwargs["endpoints"] == [
+                mock_agentverse_config.proxy_endpoint
+            ]
+
+    def test_metadata_is_public_and_geolocation_are_overridden_by_function_parameters(
+        self, registration_params: dict
+    ):
+        metadata_with_conflicts = {
+            "is_public": "False",
+            "geolocation": {"lat": "0", "lng": "0"},
+            "other_key": "other_value",
+        }
+        geo_location = AgentGeoLocation(latitude=51.5074, longitude=-0.1278)
+
+        with (
+            mock.patch(
+                "fetchai.registration.register_in_almanac", return_value=True
+            ) as mock_almanac,
+            mock.patch(
+                "fetchai.registration.register_in_agentverse", return_value=True
+            ),
+        ):
+            register_with_agentverse(
+                geo_location=geo_location,
+                metadata=metadata_with_conflicts,
+                is_public=True,
+                **registration_params,
+            )
+
+            almanac_call_args = mock_almanac.call_args
+            final_metadata = almanac_call_args.kwargs["metadata"]
+
+            assert final_metadata["is_public"] == "True"
+            assert final_metadata["geolocation"] == geo_location.as_str_dict()
+            assert final_metadata["other_key"] == "other_value"


### PR DESCRIPTION
## Summary
This PR modifies `register_with_agentverse()` to return a boolean indicating whether the registration was successful, instead of returning `None`.

## Motivation
Previously, callers of `register_with_agentverse()` had no way to determine if the registration was successful.

## Changes
- **Function signature**: Changed return type from `None` to `bool`
- **Return logic**: Returns `True` when both Almanac and Agentverse registrations succeed, `False` otherwise