### PR TITLE
feat: Add optional prefix argument to `register_with_agentverse`

### DIFF
--- a/fetchai/registration.py
+++ b/fetchai/registration.py
@@ -2,7 +2,7 @@ from uagents_core.config import DEFAULT_AGENTVERSE_URL, AgentverseConfig
 from uagents_core.contrib.protocols.chat import chat_protocol_spec
 from uagents_core.identity import Identity
 from uagents_core.registration import AgentUpdates, AgentverseConnectRequest
-from uagents_core.types import AgentType
+from uagents_core.types import AddressPrefix, AgentType
 from uagents_core.utils.registration import register_in_agentverse, register_in_almanac
 
 from fetchai.logger import get_logger
@@ -23,6 +23,7 @@ def register_with_agentverse(
     *,
     protocol_digest: str = chat_protocol_spec.digest,
     agent_type: AgentType = "custom",
+    prefix: AddressPrefix | None = None,
     is_public: bool = True,
     agentverse_base_url: str = DEFAULT_AGENTVERSE_URL,
 ) -> bool:
@@ -37,6 +38,7 @@ def register_with_agentverse(
     :param metadata: Additional data related to the agent.
     :param avatar_url: The URL of the agent's avatar.
     :param geo_location: The location of the agent
+    :param prefix: The agent's address prefix
     :param is_public: Denotes if the agent should be retrieved by Agentverse search by default.
     :param agentverse_base_url: The base url of the Agentverse environment we would like to use.
     :return: True if registration was successful in both Almanac and Agentverse, False otherwise.
@@ -67,6 +69,7 @@ def register_with_agentverse(
         protocol_digests=[protocol_digest],
         metadata=metadata,
         agentverse_config=agentverse_config,
+        prefix=prefix,
     )
 
     if not register_in_almanac_success:

--- a/fetchai/tests/test_registration.py
+++ b/fetchai/tests/test_registration.py
@@ -92,6 +92,7 @@ class TestRegisterWithAgentverse:
                 geo_location=geo_location,
                 metadata=metadata,
                 agent_type="proxy",
+                prefix="not-real-prefix",
                 **registration_params,
             )
 
@@ -109,6 +110,7 @@ class TestRegisterWithAgentverse:
                 "geolocation": geo_location.as_str_dict(),
             }
             assert almanac_call_args.kwargs["metadata"] == expected_metadata
+            assert almanac_call_args.kwargs["prefix"] == "not-real-prefix"
 
             mock_agentverse.assert_called_once()
             agentverse_call_args = mock_agentverse.call_args


### PR DESCRIPTION
A `prefix` argument is added to the `register_with_agentverse` function so that we'll be able to register flockx agents from the `platform` with the "agent" prefix (to the mainnet contract). That way, flockx agents will only need to be re-registered every 7 days instead of 2.